### PR TITLE
Add compression option to openfret.write in matlab

### DIFF
--- a/matlab/openfret.m
+++ b/matlab/openfret.m
@@ -18,23 +18,31 @@ classdef openfret
                 error('OpenFRET:read:JSONError', 'Error decoding JSON file: %s', ME.message);
             end
 
-            dataset = OpenFRET.validateDataset(data);
+            dataset = openfret.validateDataset(data);
 
         end
 
-        function write(dataset, filepath)
+        function write(dataset, filepath, varargin)
             % Writes a Dataset to a JSON file.
             %
             % Args:
             %   dataset (struct): The Dataset structure.
             %   filepath (str): Path to the JSON file.
+            %   optional (str): 'compress' to use .zip compression
 
-            dataset = OpenFRET.validateDataset(dataset);
+            dataset = openfret.validateDataset(dataset);
             try
                 jsontext = jsonencode(dataset, 'PrettyPrint', true);
                 fid = fopen(filepath, 'w');
                 fprintf(fid, '%s', jsontext);
                 fclose(fid);
+                if numel(varargin)>0
+                    if strcmpi(varargin{1},'compress')
+                        zipfilename = strcat(filepath,'.zip');
+                        zip(zipfilename,filepath);
+                        delete(filepath);
+                    end
+                end
             catch ME
                 error('OpenFRET:write:JSONError', 'Error encoding or writing JSON file: %s', ME.message);
             end


### PR DESCRIPTION
1. Add option to specify third argument, 'compress', in matlab version of openfret.write(), to perform zip compression of OpenFRET .json file.
2. Fix capitalization in reference to OpenFRET class in openfret.m when invoking static method openfret.validateDataset() -- attempts at dataset validation were throwing errors due to incorrect capitalization.